### PR TITLE
(fix) added dependency module-alias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "dsabot",
       "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "discord.js": "^12.5.3",
         "dotenv": "^8.2.0",
+        "module-alias": "^2.2.2",
         "nedb": "^1.8.0",
         "node-fetch": "^2.6.1",
         "random": "^3.0.5"
@@ -673,6 +673,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -1889,7 +1890,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -3137,6 +3139,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -3882,6 +3885,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/module-alias": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
+      "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -9364,6 +9372,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "module-alias": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
+      "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "discord.js": "^12.5.3",
     "dotenv": "^8.2.0",
+    "module-alias": "^2.2.2",
     "nedb": "^1.8.0",
     "node-fetch": "^2.6.1",
     "random": "^3.0.5"


### PR DESCRIPTION
This should fix the following error:

```
node:internal/modules/cjs/loader:927
  throw err;
  ^

Error: Cannot find module '@dsabot/findMessage'
Require stack:
- /usr/src/app/commands/Attack.js
- /usr/src/app/index.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:924:15)
    at Function.Module._load (node:internal/modules/cjs/loader:769:27)
    at Module.require (node:internal/modules/cjs/loader:996:19)
    at require (node:internal/modules/cjs/helpers:92:18)
    at Object.<anonymous> (/usr/src/app/commands/Attack.js:5:24)
    at Module._compile (node:internal/modules/cjs/loader:1092:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1121:10)
    at Module.load (node:internal/modules/cjs/loader:972:32)
    at Function.Module._load (node:internal/modules/cjs/loader:813:14)
    at Module.require (node:internal/modules/cjs/loader:996:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/usr/src/app/commands/Attack.js', '/usr/src/app/index.js' ]
}
```